### PR TITLE
Upgrade YACReader (unarr) from 9.8.2 to 9.9.1

### DIFF
--- a/unarr/Dockerfile
+++ b/unarr/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:focal
+FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy
 
 # package versions
-ARG YACR_VERSION="9.8.2"
+ARG YACR_VERSION="9.9.1"
 
 # env variables
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -18,7 +18,6 @@ RUN \
        desktop-file-utils \
        g++ \
        git \
-       qt5-default \
        libbz2-dev \
        libglu1-mesa-dev \
        liblzma-dev \
@@ -36,7 +35,6 @@ RUN \
        libqt5sql5 \
        libqt5svg5 \
        libsqlite3-dev \
-       libwebp6 \
        make \
        qtbase5-dev \
        qt5-image-formats-plugins \


### PR DESCRIPTION
* Upgrades Ubuntu from focal to jammy to satisfy new YACReader dependencies
* Updates Dockerfile to remove references to packages not present in Ubuntu jammy

This only handles the x86_64 / unarr version but hopefully provides a path forward for upgrading the other architectures.