### PR TITLE
docs: remove obsolete docker compose version field from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ docker run -d \
 
 ```yaml
 ---
-version: "3"
 services:
   yacreaderlibrary-server-docker:
     container_name: YACReaderLibraryServer


### PR DESCRIPTION
The `version:` key is . Docker Compose V2 uses the Compose Specification and will warn that `version` is obsolete.